### PR TITLE
Fix segfault when closing a non-existing file

### DIFF
--- a/source/tools/performance_test/main.cpp
+++ b/source/tools/performance_test/main.cpp
@@ -21,9 +21,14 @@ bool fileIsPresent()
 {
     FILE *h;
     h = fopen("data.dat", "r+b");
-    bool res = !(h == NULL);
+    
+    if (!h)
+    {
+        return false;
+    }
+
     fclose(h);
-    return res;
+    return true;
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
This occurs if `h == nullptr`